### PR TITLE
feat: figuring stationNum by stationName

### DIFF
--- a/service/finedustService.js
+++ b/service/finedustService.js
@@ -1,4 +1,5 @@
 var api_config = require("../config/finedustApiConfig.json");
+var stationNumbering = require("../config/finedustStationNumber.json");
 var request = require("request");
 
 async function getFinedust(stationName) {
@@ -11,8 +12,14 @@ async function getFinedust(stationName) {
 }
 
 function getStationNumber(stationName) {
-  stationNumber = stationName;
-  return 3;
+  for (var i = 1; i < 9; i++) {
+    var checkStation =
+      stationNumbering[i.toString()].hasOwnProperty(stationName);
+    if (checkStation) {
+      return stationNumbering[i.toString()][stationName];
+    }
+  }
+  return -1;
 }
 
 function finedustRequireURLResolver(key, stationName) {


### PR DESCRIPTION
complexity와 마찬가지로 -1로 러프하게 에러 디텍팅했음.
여기는 호선이 겹치는 경우 낮은 번호의 호선에 해당 역이 없기도 해서 나중에 살펴볼 필요가 있어요.
당장 건대입구역만 해도 7호선만 제공 중임
근데 서울역 보면 1, 4호선 다 있음. 무언가 확인이 필요할 듯.
2호선 numbering이 안 끊기는 것을 보면 건대입구역 2호선은 제공을 안 하는 것이 맞는 것 같아요.