### PR TITLE
Feat/complexity subway numbering

### DIFF
--- a/service/complexityService.js
+++ b/service/complexityService.js
@@ -5,8 +5,10 @@ var request = require("request");
 async function getComplexity(stationName) {
   const authKey = api_config.Encoding;
 
-  var requesturl = complexRequireURLResolver(authKey, stationName);
-  console.log(requesturl);
+  var now = new Date();
+  var dayOfWeek = now.getDay();
+
+  var requesturl = complexRequireURLResolver(authKey, stationName, dayOfWeek);
   var res_json = JSON.parse(await getJSON(requesturl));
   var keys = [0, 0, 0, 0];
   var values = [100.0, 0.0, 100.0, 0.0];
@@ -27,8 +29,6 @@ async function getComplexity(stationName) {
       values[1 + loop * 2] = Math.max(value, values[1 + loop * 2]);
     }
   }
-  console.log(values);
-  console.log(keys);
   return keys;
 }
 
@@ -55,11 +55,15 @@ function getStationNumber(stationName) {
   return -1;
 }
 
-function complexRequireURLResolver(key, stationName) {
-  base_url = api_config.base_url;
-  page = "page=" + getStationNumber(stationName);
-  perPage = "perPage=2";
-  serviceKey = "serviceKey=" + key;
+function complexRequireURLResolver(key, stationName, dayOfWeek) {
+  var base_url = api_config.base_url;
+  var multiplier = 0;
+  if (dayOfWeek == 0) multiplier = 284 * 2;
+  if (dayOfWeek == 6) multiplier = 284;
+  var querryNumber = getStationNumber(stationName) * 1 + multiplier;
+  var page = "page=" + querryNumber;
+  var perPage = "perPage=2";
+  var serviceKey = "serviceKey=" + key;
 
   return base_url + "?" + page + "&" + perPage + "&" + serviceKey;
 }

--- a/service/complexityService.js
+++ b/service/complexityService.js
@@ -1,10 +1,12 @@
 var api_config = require("../config/complexityApiConfig.json");
+var stationNumbering = require("../config/complexityStationNumber.json");
 var request = require("request");
 
 async function getComplexity(stationName) {
   const authKey = api_config.Encoding;
 
   var requesturl = complexRequireURLResolver(authKey, stationName);
+  console.log(requesturl);
   var res_json = JSON.parse(await getJSON(requesturl));
   var keys = [0, 0, 0, 0];
   var values = [100.0, 0.0, 100.0, 0.0];
@@ -43,8 +45,14 @@ function getJSON(url) {
 }
 
 function getStationNumber(stationName) {
-  stationNumber = stationName;
-  return 3;
+  for (var i = 1; i < 9; i++) {
+    var checkStation =
+      stationNumbering[i.toString()].hasOwnProperty(stationName);
+    if (checkStation) {
+      return stationNumbering[i.toString()][stationName];
+    }
+  }
+  return -1;
 }
 
 function complexRequireURLResolver(key, stationName) {


### PR DESCRIPTION
기본적으로 잘못된 지하철역명을 검색한 경우 getStatinNumber에서 -1을 리턴하여 에러를 유발하고 있습니다.

노선이 겹치는 경우는 issue #21에서 다룹니다.

또한 요일을 판별하여 평일/토요일/일요일에 나누어 혼잡도를 제공하는 로직 역시 작성했습니다. 다만 지하철이 00시에 운행을 종료하는 것이 아니기 때문에, 더 올바른 서비스를 위해서는 이를 다루는 추가적인 로직 역시 필요합니다. ex) 새벽 3시가 넘어야 해당 요일의 정보를 제공